### PR TITLE
Optimize tagDestinationMap lookup

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -152,7 +152,7 @@ FileNameLinkedMap    *Doxygen::mscFileNameLinkedMap = nullptr;     // msc files
 FileNameLinkedMap    *Doxygen::diaFileNameLinkedMap = nullptr;     // dia files
 FileNameLinkedMap    *Doxygen::plantUmlFileNameLinkedMap = nullptr;// plantuml files
 NamespaceAliasInfoMap Doxygen::namespaceAliasMap;            // all namespace aliases
-StringMap             Doxygen::tagDestinationMap;            // all tag locations
+StringUnorderedMap    Doxygen::tagDestinationMap;            // all tag locations
 StringUnorderedSet    Doxygen::tagFileSet;                   // all tag file names
 StringUnorderedSet    Doxygen::expandAsDefinedSet;           // all macros that should be expanded
 MemberGroupInfoMap    Doxygen::memberGroupInfoMap;           // dictionary of the member groups heading

--- a/src/doxygen.h
+++ b/src/doxygen.h
@@ -113,7 +113,7 @@ class Doxygen
     static NamespaceAliasInfoMap     namespaceAliasMap;
     static GroupLinkedMap           *groupLinkedMap;
     static NamespaceLinkedMap       *namespaceLinkedMap;
-    static StringMap                 tagDestinationMap;
+    static StringUnorderedMap        tagDestinationMap;
     static StringUnorderedSet        tagFileSet;
     static MemberGroupInfoMap        memberGroupInfoMap;
     static StringUnorderedSet        expandAsDefinedSet;


### PR DESCRIPTION
## Summary
- replace `StringMap` with `StringUnorderedMap` for `tagDestinationMap`

## Testing
- `python3 testing/runtests.py --id 001` *(fails: missing doxygen binary)*

------
https://chatgpt.com/codex/tasks/task_e_6873aa8809808321831639e30639aff1