### PR TITLE
Optimize resource lookup

### DIFF
--- a/src/resourcemgr.cpp
+++ b/src/resourcemgr.cpp
@@ -13,7 +13,7 @@
  *
  */
 
-#include <map>
+#include <unordered_map>
 #include <string.h>
 #include <cstdint>
 
@@ -26,8 +26,8 @@
 
 class ResourceMgr::Private
 {
-  public:
-    std::map<std::string,Resource> resources;
+	public:
+	std::unordered_map<std::string,Resource> resources;
 };
 
 ResourceMgr &ResourceMgr::instance()


### PR DESCRIPTION
## Summary
- use `unordered_map` for resource lookup

## Testing
- `cmake ..` *(fails: Could NOT find FLEX)*

------
https://chatgpt.com/codex/tasks/task_e_6873aa8809808321831639e30639aff1