### PR TITLE
Optimize external search index lookup

### DIFF
--- a/src/searchindex.cpp
+++ b/src/searchindex.cpp
@@ -17,7 +17,6 @@
 #include <ctype.h>
 #include <assert.h>
 #include <mutex>
-#include <map>
 #include <unordered_map>
 
 #include "searchindex.h"

--- a/src/searchindex.h
+++ b/src/searchindex.h
@@ -24,7 +24,6 @@
 
 #include <memory>
 #include <vector>
-#include <map>
 #include <unordered_map>
 #include <string>
 #include <array>
@@ -129,7 +128,7 @@ class SearchIndexExternal
     void addWord(const QCString &word,bool hiPriority);
     void write(const QCString &file);
   private:
-    std::map<std::string,SearchDocEntry> m_docEntries;
+    std::unordered_map<std::string,SearchDocEntry> m_docEntries;
     SearchDocEntry *m_current = nullptr;
 };
 


### PR DESCRIPTION
## Summary
- switch SearchIndexExternal to use `std::unordered_map`

## Testing
- `cmake -S . -B build -GNinja`
- `cmake --build build --target doxygen` *(fails: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6873ae168740832197ef34de3af1c8a0